### PR TITLE
Fix #4: Add price quoted warning when markup changes from proposal

### DIFF
--- a/app.py
+++ b/app.py
@@ -1592,6 +1592,18 @@ with tab2:
 
                     st.caption(f"Client price: ${client_price_per_unit:.2f}/unit (before customization)")
 
+                    # Show quoted price warning if this came from a proposal and price changed
+                    quoted_price = item.get('quoted_price_per_unit', 0.0)
+                    if quoted_price > 0:
+                        # Product came from proposal - show comparison
+                        if abs(client_price_per_unit - quoted_price) > 0.01:  # Allow for rounding errors
+                            st.warning(f"⚠️ Price changed from proposal: Quoted price was ${quoted_price:.2f}/unit")
+                        else:
+                            st.info(f"✓ Matches quoted price: ${quoted_price:.2f}/unit")
+                    else:
+                        # Product added manually (not from proposal)
+                        st.caption("Quoted price: Unknown (product added manually)")
+
             # CUSTOMIZATION SECTION (always available)
             customization_info = product_data.get("Customization Info", "")
             st.markdown("##### Customization (Optional)")

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -378,6 +378,9 @@ def convert_proposal_to_order(proposal_item, get_unit_price_func, calculate_tari
     # Calculate per-unit total
     total_per_unit = product_total / quantity
 
+    # Store quoted price (product + markup, before customization) for comparison in Tab 2
+    quoted_price_per_unit = (product_cost_subtotal + markup_amount) / quantity
+
     # Parse tariff info
     tariff_rate_percent = parse_tariff_rate(product_data.get('Tariff Rate', ''))
     tariff_base = product_cost_subtotal  # Tariff on product cost only (excludes customization)
@@ -419,6 +422,7 @@ def convert_proposal_to_order(proposal_item, get_unit_price_func, calculate_tari
         'subtotal_before_markup': product_cost_subtotal + customization_setup_total + customization_unit_total,
         'product_total': product_total,  # Product + markup + customization
         'total_per_unit': total_per_unit,  # Total divided by quantity
+        'quoted_price_per_unit': quoted_price_per_unit,  # Price quoted in proposal (for comparison)
 
         # Tariff
         'country_of_origin': product_data.get('Country of Origin', 'Unknown'),


### PR DESCRIPTION
## Summary
- Added quoted price tracking from proposals to Tab 2
- Displays warning when order price differs from quoted price
- Prevents accidental price changes to clients

## Problem
When importing products from proposals to orders, users could accidentally change the markup and charge clients a different price than originally quoted, without realizing it.

## Solution
Track the quoted price when importing from proposals and display a clear warning if the price changes.

## Changes Made

### Data Storage (src/helpers.py)
- **convert_proposal_to_order():** Added `quoted_price_per_unit` calculation
  ```python
  quoted_price_per_unit = (product_cost + markup) / quantity
  ```
- Price excludes customization (matches "Client price" display)
- Stored in order item dictionary for Tab 2 comparison

### Tab 2 Display (app.py)
- **Added price comparison under "Client price" display:**
  - **Green info box:** "✓ Matches quoted price: $15.00/unit"
  - **Yellow warning:** "⚠️ Price changed from proposal: Quoted price was $15.00/unit"
  - **Gray caption:** "Quoted price: Unknown (product added manually)"
- **Tolerance:** 1¢ allowance for rounding errors
- **Real-time:** Updates instantly as user edits markup %

## User Experience

### Scenario 1: Price Unchanged
```
Client price: $15.00/unit (before customization)
✓ Matches quoted price: $15.00/unit
```

### Scenario 2: Price Changed
User changes markup from 100% to 120%:
```
Client price: $18.00/unit (before customization)
⚠️ Price changed from proposal: Quoted price was $15.00/unit
```

### Scenario 3: Manually Added Product
```
Client price: $20.00/unit (before customization)
Quoted price: Unknown (product added manually)
```

## Testing
- [x] Quoted price stored when importing from proposal
- [x] Warning appears when markup changes
- [x] Info box appears when price matches
- [x] "Unknown" displays for manually-added products
- [x] Rounding tolerance works (±$0.01)
- [x] Works with all products (tiered and flat-rate)

## Closes
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)